### PR TITLE
Rename master branch to main

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -6,7 +6,7 @@ repository:
   has_projects: false
   has_wiki: false
   has_downloads: true
-  default_branch: master
+  default_branch: main
   allow_squash_merge: false
   allow_merge_commit: true
   allow_rebase_merge: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Play socket.io support
 
-[![Build Status](https://travis-ci.org/playframework/play-socket.io.png?branch=master)](https://travis-ci.org/playframework/play-socket.io) [![Latest Release](https://img.shields.io/maven-central/v/com.lightbend.play/play-socket-io_2.12.svg)](https://mvnrepository.com/artifact/com.lightbend.play/play-socket-io_2.12)
+[![Build Status](https://travis-ci.org/playframework/play-socket.io.png?branch=main)](https://travis-ci.org/playframework/play-socket.io) [![Latest Release](https://img.shields.io/maven-central/v/com.lightbend.play/play-socket-io_2.12.svg)](https://mvnrepository.com/artifact/com.lightbend.play/play-socket-io_2.12)
 
 This is the Play backend socket.io support.
 


### PR DESCRIPTION
@SethTisue and @ihostage already renamed the `master` branch in some play repos:
* https://github.com/playframework/cachecontrol/pull/163
* https://github.com/playframework/play-file-watch/pull/136
* https://github.com/playframework/play-json/pull/598
* https://github.com/playframework/play-soap/pull/282
* https://github.com/playframework/play-ws/pull/597
* https://github.com/playframework/twirl/pull/416

Now that we are centralising configs in the [`.github`](https://github.com/playframework/.github) repo it's a good idea that all repos have the same default branch name.

To change to `main` locally (if the remote to this repo is called `upstream`):
```sh
git branch -m master main # rename master to main (actually "move")
git fetch upstream
git branch -u upstream/main main # set upstream
git remote set-head upstream -a # make sure HEAD is set correctly for this remote (autodetect)
```